### PR TITLE
Change the way we handle the payment term line dates, we save a small…

### DIFF
--- a/locale/ca.po
+++ b/locale/ca.po
@@ -2,7 +2,6 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=utf-8\n"
 
-#, fuzzy
 msgctxt "field:account.invoice,payment_days:"
 msgid "Payment Days"
 msgstr "Dies de pagament"

--- a/payment_term.py
+++ b/payment_term.py
@@ -39,25 +39,25 @@ class PaymentTermLine(metaclass=PoolMeta):
         'account_payment_days' key in context which may contain a list
         of payment days.
         '''
+        transaction = Transaction()
         base_date = date
         for relativedelta_ in self.relativedeltas:
             base_date += relativedelta_.get()
 
         nominal_date = self.next_payment_day(base_date)
         final_date = nominal_date
-        if (Transaction().context.get('account_payment_holidays')
+        if (transaction.context.get('account_payment_holidays')
                 and hasattr(self, 'next_working_day')):
             working_date = self.next_working_day(final_date)
             while final_date != working_date:
                 final_date = self.next_payment_day(working_date)
                 working_date = self.next_working_day(final_date)
 
-        transaction = Transaction()
         state_key = (
             self.payment.id if self.payment else None,
             date,
-            tuple(Transaction().context.get('account_payment_days') or ()),
-            tuple(Transaction().context.get('account_payment_holidays') or ()),
+            tuple(transaction.context.get('account_payment_days') or ()),
+            tuple(transaction.context.get('account_payment_holidays') or ()),
             )
         state = getattr(transaction, '_account_payment_days_state', None)
         if (state
@@ -67,7 +67,7 @@ class PaymentTermLine(metaclass=PoolMeta):
                 and final_date <= state['final_date']):
             final_date = self.next_payment_day(
                 state['final_date'] + relativedelta(days=1))
-            if (Transaction().context.get('account_payment_holidays')
+            if (transaction.context.get('account_payment_holidays')
                     and hasattr(self, 'next_working_day')):
                 working_date = self.next_working_day(final_date)
                 while final_date != working_date:

--- a/payment_term.py
+++ b/payment_term.py
@@ -39,11 +39,44 @@ class PaymentTermLine(metaclass=PoolMeta):
         'account_payment_days' key in context which may contain a list
         of payment days.
         '''
-        date = super(PaymentTermLine, self).get_date(date)
-        date = self.next_payment_day(date)
-        if Transaction().context.get('account_payment_holidays'):
-            working_date = self.next_working_day(date)
-            while date != working_date:
-                date = self.next_payment_day(working_date)
-                working_date = self.next_working_day(date)
-        return date
+        base_date = date
+        for relativedelta_ in self.relativedeltas:
+            base_date += relativedelta_.get()
+
+        nominal_date = self.next_payment_day(base_date)
+        final_date = nominal_date
+        if (Transaction().context.get('account_payment_holidays')
+                and hasattr(self, 'next_working_day')):
+            working_date = self.next_working_day(final_date)
+            while final_date != working_date:
+                final_date = self.next_payment_day(working_date)
+                working_date = self.next_working_day(final_date)
+
+        transaction = Transaction()
+        state_key = (
+            self.payment.id if self.payment else None,
+            date,
+            tuple(Transaction().context.get('account_payment_days') or ()),
+            tuple(Transaction().context.get('account_payment_holidays') or ()),
+            )
+        state = getattr(transaction, '_account_payment_days_state', None)
+        if (state
+                and state.get('key') == state_key
+                and state['base_date'] < base_date
+                and state['nominal_date'] < state['final_date']
+                and final_date <= state['final_date']):
+            final_date = self.next_payment_day(
+                state['final_date'] + relativedelta(days=1))
+            if (Transaction().context.get('account_payment_holidays')
+                    and hasattr(self, 'next_working_day')):
+                working_date = self.next_working_day(final_date)
+                while final_date != working_date:
+                    final_date = self.next_payment_day(working_date)
+                    working_date = self.next_working_day(final_date)
+        transaction._account_payment_days_state = {
+            'key': state_key,
+            'base_date': base_date,
+            'nominal_date': nominal_date,
+            'final_date': final_date,
+            }
+        return final_date

--- a/tests/test_scenario_invoice_holidays.py
+++ b/tests/test_scenario_invoice_holidays.py
@@ -1,0 +1,88 @@
+import datetime
+import unittest
+from decimal import Decimal
+
+from proteus import Model
+from trytond.modules.account.tests.tools import (
+    create_chart, create_fiscalyear, get_accounts)
+from trytond.modules.account_invoice.tests.tools import (
+    set_fiscalyear_invoice_sequences)
+from trytond.modules.company.tests.tools import create_company, get_company
+from trytond.tests.test_tryton import drop_db
+from trytond.tests.tools import activate_modules
+
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        drop_db()
+        super().setUp()
+
+    def tearDown(self):
+        drop_db()
+        super().tearDown()
+
+    def test(self):
+        today = datetime.date(2026, 1, 1)
+        activate_modules(['account_payment_days', 'account_payment_holidays'])
+
+        _ = create_company()
+        company = get_company()
+
+        fiscalyear = set_fiscalyear_invoice_sequences(
+            create_fiscalyear(company, today=today))
+        fiscalyear.click('create_period')
+
+        _ = create_chart(company)
+        accounts = get_accounts(company)
+        receivable = accounts['receivable']
+        revenue = accounts['revenue']
+
+        Party = Model.get('party.party')
+        PaymentHolidays = Model.get('party.payment.holidays')
+        party = Party(name='Party')
+        party.customer_payment_days = '30'
+        party.payment_holidays.append(PaymentHolidays(
+                from_month='08',
+                from_day=1,
+                thru_month='08',
+                thru_day=31,
+                ))
+        party.save()
+
+        PaymentTerm = Model.get('account.invoice.payment_term')
+        payment_term = PaymentTerm(name='Three Months')
+        line = payment_term.lines.new(type='percent', ratio=Decimal('0.3333333333'))
+        line.relativedeltas.new(months=1)
+        line = payment_term.lines.new(type='percent', ratio=Decimal('0.3333333333'))
+        line.relativedeltas.new(months=2)
+        line = payment_term.lines.new(type='remainder')
+        line.relativedeltas.new(months=3)
+        payment_term.save()
+
+        Invoice = Model.get('account.invoice')
+        InvoiceLine = Model.get('account.invoice.line')
+        invoice = Invoice()
+        invoice.party = party
+        invoice.payment_term = payment_term
+        invoice.payment_term_date = datetime.date(2026, 6, 15)
+        invoice.invoice_date = datetime.date(2026, 6, 15)
+        line = InvoiceLine()
+        invoice.lines.append(line)
+        line.account = revenue
+        line.description = 'Line'
+        line.quantity = 1
+        line.unit_price = Decimal('300')
+
+        invoice.click('post')
+        self.assertEqual(invoice.state, 'posted')
+
+        maturity_dates = sorted(
+            line.maturity_date
+            for line in invoice.move.lines
+            if line.account == receivable)
+        self.assertEqual(maturity_dates, [
+                datetime.date(2026, 7, 30),
+                datetime.date(2026, 9, 30),
+                datetime.date(2026, 10, 30),
+                ])


### PR DESCRIPTION
… context with the information of the last payment line on the same invoice to know which date we need to use for the next payment line.

Here we include too the possible modifications on the payment term line date taking into account the holidays days configured on the invoice party. Add a new test to validate the extra dependency with "account_payment_holidays" module. Fix fuzzy ca locales.

Task #188789